### PR TITLE
Fix package.json parsing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "start": "node server/index.js",
     "test": "jest",
     "docker:build": "docker build -t h-pos .",
-    "docker:run": "docker-compose up -d",
-
+    "docker:run": "docker-compose up -d"
   },
   "dependencies": {
     "express": "^4.18.2",


### PR DESCRIPTION
Remove trailing comma in `package.json` to fix JSON parsing error during deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc385156-9d0c-481b-a98a-863fdc276810">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc385156-9d0c-481b-a98a-863fdc276810">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

